### PR TITLE
Added the ability to view the repository in a new tab by clicking name/image

### DIFF
--- a/resources/js/Components/RepoForks.vue
+++ b/resources/js/Components/RepoForks.vue
@@ -27,13 +27,15 @@
                     <div class="w-full flex flex-wrap justify-between items-center">
                         <div class="flex-1 flex">
                             <div class="mr-4" style="width: 48px; height:48px;">
-                                <img :src="fork.owner.avatar_url" />
+                                <a class="block w-full" :href="`https://gihub.com/${fork.owner.id}/${fork.name}`" target="_blank">
+                                    <img :src="fork.owner.avatar_url" />
+                                </a>
                             </div>
 
                             <div class="w-auto">
-                                <span class="capitalize text-xl font-semibold">
+                                <a class="capitalize text-xl font-semibold" :href="`https://gihub.com/${fork.owner.id}/${fork.name}`" target="_blank">
                                     {{ fork.owner.id }}
-                                </span>
+                                </a>
 
                                 <div class="flex text-black flex-col sm:flex-row text-gray-600">
                                     <div class="flex items-center mr-4 mb-1 sm:mb-0">

--- a/resources/js/Components/RepositoryHeader.vue
+++ b/resources/js/Components/RepositoryHeader.vue
@@ -2,13 +2,17 @@
     <div>
         <div class="flex flex-col sm:flex-row mb-4">
             <div style="width: 75px; height:75px" class="mr-4">
-                <img :src="repository.owner.avatar_url" />
+                <a class="block w-full" :href="`https://gihub.com/${repository.owner.id}/${repository.name}`" target="_blank">
+                    <img :src="repository.owner.avatar_url" />
+                </a>
             </div>
             <div class="flex flex-col">
-                <h1 class="flex flex-col sm:flex-row mb-2">
-                    <span class="text-md sm:text-xl">{{ repository.owner.id }}</span>
-                    <span class="text-xl mx-2 hidden sm:block">/</span>
-                    <span class="text-xl font-semibold">{{ repository.name }}</span>
+                <h1 class="mb-2">
+                    <a class="flex flex-col sm:flex-row" :href="`https://gihub.com/${repository.owner.id}/${repository.name}`" target="_blank">
+                        <span class="text-md sm:text-xl">{{ repository.owner.id }}</span>
+                        <span class="text-xl px-2 hidden sm:block">/</span>
+                        <span class="text-xl font-semibold">{{ repository.name }}</span>
+                    </a>
                 </h1>
                 <div class="mb-2">
                     <p class="text-sm text-gray-700">{{ repository.description }}</p>


### PR DESCRIPTION
## Pull Request Type

What kind of change does this PR introduce?

- Bugfix
- Feature

## What is the current behavior?

Currently, there is no way to view the main repository in GitHub in a new tab.


## What is the new behavior?

The user can now open the main repository in GitHub in a new tab by clicking the avatar / name of the repository
