### PR TITLE
Enforce HTTPS in production

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace App\Providers;
 
-use App\Services\GitHub;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -24,6 +24,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        if ($this->app->environment('production')) {
+            URL::forceScheme('https');
+        }
     }
 }


### PR DESCRIPTION
## Pull Request Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The anchor tags on production can sometimes link to use the `http` scheme and is being blocked at browser level.


## What is the new behavior?

All links generated inside the Laravel framework are enforced to use the `https` scheme and will need to ensure the environment also has the `APP_URL` as `https://pedigree.sh` 